### PR TITLE
Bump closure-linter-wrapper to v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "chalk": "^0.5.1",
-    "closure-linter-wrapper": "^0.2.9",
+    "closure-linter-wrapper": "^1.0.1",
     "gulp-util": "^3.0.0",
     "merge": "^1.1.3",
     "through2": "^0.5.1"


### PR DESCRIPTION
Bumps version of `closure-linter-wrapper` to the latest version (1.0.1) as requested in #15.

The only breaking change appears to be dropping support for the `ignore_errors` flag. See https://github.com/jmendiara/node-closure-linter-wrapper/releases/tag/1.0.0